### PR TITLE
Library fails for any process.arch other than x86 and x64

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import murmurhash3js from 'murmurhash3js'
 import async from 'async'
 import parameters from './parameters'
 import traverse from 'traverse'
-const hash = murmurhash3js[process.arch]
+const hash = murmurhash3js.x64
 
 const Fingerprint = setting => {
   const config = {


### PR DESCRIPTION
I was attempting to use this library on an Azure App Service which uses a version of Node w/ process.arch = ia32. The murmurhash3js hash algorithms are not bound to a specific architecture, they just return hashes based on 32 or 64 bit integer values. There are only 2 valid values in the murmurhash3js library: x86 and x64.  

To address the issue, I forced the x64 version of the hashing algorithm regardless of the Node architecture. While it could still be bound to the process.arch, it would have to take into account all of the available values for that variable:

'arm', 'arm64', 'ia32', 'mips', 'mipsel', 'ppc', 'ppc64', 's390', 's390x', 'x32', and 'x64'.