### PR TITLE
fix getting client's ip address from behind of proxies

### DIFF
--- a/src/parameters/geoip.ts
+++ b/src/parameters/geoip.ts
@@ -9,7 +9,7 @@ export interface GeoIp extends FingerprintResultComponent {
 
 export const geoip: FingerprintParameter<GeoIp> = function (next) {
   const ip =
-    (this.req.headers["x-forwarded-for"] || "").split(",").pop() ||
+    (this.req.headers["x-forwarded-for"] || "").split(",")[0] ||
     this.req.connection?.remoteAddress ||
     this.req.socket?.remoteAddress ||
     this.req.connection?.socket?.remoteAddress ||


### PR DESCRIPTION
When using this library for clients fingerprinting I stumbled upon an issue in which hash I was using to identify clients was different on every request. Trying to figure out what the problem was, I quickly looked through source code and figured out which IP address was chosen first from request object for geoIP lookup, which was the last one in list of X-Forwarder-For header. Searching more info on regard of content of this header I stumbled across this Mozilla Developers breakdown of header X-Forwarded-For: <client>, <proxy1>, <proxy2>. I realized that instead of taking client's actual IP address library was passing CloudFlare's last CDN's IP address to geoIP lookup, and considering that they use load balancers, this last IP address was different each time.

Long story short, this pull request fixes getting load balancer's IP address instead of client's IP by replacing 
pop() with [0] on array of IP addresses.